### PR TITLE
feat: announcement & tests

### DIFF
--- a/backend/kalunwa/content/serializers.py
+++ b/backend/kalunwa/content/serializers.py
@@ -328,17 +328,20 @@ class ContributorSerializer(FlexFieldsModelSerializer):
 #  serializes all data fields
 
 
-class AnnouncementSerializer(serializers.ModelSerializer):
-
+class AnnouncementSerializer(FlexFieldsModelSerializer):
+    date = serializers.SerializerMethodField()    
     class Meta:
         model = Announcement
         fields = (
             'id',
             'title',
             'description',
+            'date',
             'created_at',
             'updated_at',
         )
+    def get_date(self, obj):
+        return to_formal_mdy(obj.created_at)
 
 
 class DemographicsSerializer(serializers.ModelSerializer):

--- a/backend/kalunwa/content/views.py
+++ b/backend/kalunwa/content/views.py
@@ -114,6 +114,7 @@ class ImageViewSet(viewsets.ModelViewSet):
 class AnnouncementViewSet(viewsets.ModelViewSet):
     serializer_class = AnnouncementSerializer
     queryset = Announcement.objects.all()
+    filter_backends = [QueryLimitBackend]
 
 
 #-------------------------------------------------------

--- a/backend/testing/test_apis.py
+++ b/backend/testing/test_apis.py
@@ -4,14 +4,14 @@ from django.utils import timezone
 from rest_framework.test import APITestCase, APIRequestFactory
 from kalunwa.content.serializers import StatusEnum
 from .utils import  (
-    ABOUT_US_CAMP_URL, ABOUT_US_LEADERS, ABOUT_US_TOTAL_MEMBERS,
+    ABOUT_US_CAMP_URL, ABOUT_US_LEADERS, ABOUT_US_TOTAL_MEMBERS, ANNOUNCEMENT_LATEST_ONE,
     EVENT_DETAIL_CONTRIBUTORS, EVENT_DETAIL_GALLERY_LIMIT,
     HOMEPAGE_NEWS_URL, HOMEPAGE_PROJECT_URL, PROJECT_DETAIL_CONTRIBUTORS, 
-    PROJECT_DETAIL_GALLERY_LIMIT, get_expected_image_url, get_test_image_file,
+    PROJECT_DETAIL_GALLERY_LIMIT, get_expected_image_url, get_test_image_file, to_expected_iso_format,
     to_formal_mdy, HOMEPAGE_JUMBOTRON_URL, HOMEPAGE_EVENT_URL
 )
 from kalunwa.content.models import(
-    CampEnum, CampLeader, CampPage, Contributor, Demographics,  Image, Jumbotron, 
+    Announcement, CampEnum, CampLeader, CampPage, Contributor, Demographics,  Image, Jumbotron, 
     News, OrgLeader, Project, Event
 )
 from rest_framework import status
@@ -929,6 +929,148 @@ class ProjectGetTestCase(APITestCase):
             'category' : expected_contributor.category.label
         } 
         self.assertDictEqual(response_contributor[0], expected_contributor_data)
+
+
+class AnnouncementGetTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:    
+        cls.request_factory = APIRequestFactory()
+
+    def test_get_announcement_list(self):
+        """
+            - test announcement endpoint (status ok), return created announcements    
+        """        
+        for _ in range(5):
+            Announcement.objects.create(
+                title='announcement',
+                description = 'description'
+            )
+        response = self.client.get(reverse('announcement-list'))
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual( len(response.data), 5)       
+
+    def test_get_announcement_detail(self):
+        """
+            - test announcement detail endpoint (status ok), return created announcement   
+        """        
+        expected_announcement = Announcement.objects.create(
+                title='announcement',
+                description = 'description'
+        )
+        response = self.client.get(reverse('announcement-detail', args=[1]))
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        response_announcement = json.loads(response.content)
+        expected_announcement_data = {
+            'id': expected_announcement.id,
+            'title': expected_announcement.title,
+            'description' : expected_announcement.description,    
+            'date': to_formal_mdy(expected_announcement.created_at),          
+            'created_at': to_expected_iso_format(expected_announcement.created_at), 
+            'updated_at': to_expected_iso_format(expected_announcement.updated_at),                      
+        }
+        self.assertDictEqual(expected_announcement_data, response_announcement)        
+
+        
+class AnnouncementLatesTTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:    
+        cls.request_factory = APIRequestFactory()
+        cls.url = ANNOUNCEMENT_LATEST_ONE
+
+    def test_get_latest_announcement(self):      
+        for _ in range(5):
+            Announcement.objects.create(
+                title='announcement',
+                description = 'description'
+            )
+
+        response = self.client.get(self.url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        expected_announcement = Announcement.objects.first() # ordered by latest
+        response_announcement = json.loads(response.content)[0]
+        latest_announcement_data = {
+            'id': expected_announcement.id,
+            'title': expected_announcement.title,
+            'description' : expected_announcement.description,  
+            'date': to_formal_mdy(expected_announcement.created_at)                  
+        }        
+        self.assertDictEqual(latest_announcement_data, response_announcement)
+
+    
+
+    
+
+
+class QueryLimitTestCase(APITestCase):
+    """
+    mock viewset that uses this logic e.g. Event
+    -> test on list endpoint
+        - mock 5 events
+        - query limit is an integer.
+        - query limit values to test: [-1, 0, 3, 5, 6]
+            # negative value
+            # zero
+            # less than total events
+            # exact no. of events
+            # greater than no. of events
+            # strings
+                # empty string
+    """
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.image_file = get_test_image_file()
+
+        for _ in range(5): 
+            Event.objects.create(
+            title= f'Event {_}', 
+            description= f'description {_}',
+            start_date=timezone.now(),
+            end_date=timezone.now(),
+            image = Image.objects.create(name=f'image_{_}', image=cls.image_file),  
+            is_featured=True,
+            )           
+
+        cls.event_count = len(Event.objects.all())            
+
+    def test_expected_query_integer_input(self):
+        # 0 -> returns 0 or no events
+        query_limit = 0
+        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
+        self.assertEqual(len(response.data), 0)
+        # 3 -> returns 3 events
+        query_limit = 3
+        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
+        self.assertEqual(len(response.data), query_limit)        
+        # 5 -> returns 5 events
+        query_limit = 5
+        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
+        self.assertEqual(len(response.data), query_limit)           
+        # 6 -> returns 5 events
+        query_limit = 6
+        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
+        self.assertEqual(len(response.data), self.event_count)
+        # aaa -> strings are ignored
+
+    def test_negative_query_integer_input(self):
+        # -1 -> ignores negative, return all events
+        query_limit = -1
+        response = self.client.get(f'/api/events/?query_limit={query_limit}')
+        self.assertEqual(len(response.data), self.event_count)
+
+    def test_string_query_input(self):
+        query_limits = ['aaa', '*&()', '']
+
+        for query_limit in query_limits:
+            response = self.client.get(f'/api/events/?query_limit={query_limit}')        
+            self.assertEqual(len(response.data), self.event_count)   
+
+"""
+Test QueryLimitBackend: Gallery
+
+tests:
+    - if no model -> error 
+    - is used by a model that has no gallery 
+""" 
 
 
 # ---------------------------------------------------------------------------        

--- a/backend/testing/test_apis.py
+++ b/backend/testing/test_apis.py
@@ -552,23 +552,8 @@ class AboutUsLeadersTestCase(APITestCase):
                 'image' : image_url
                 }
         }
-        self.assertDictEqual(expected_leader_data, response_leader)
-# ---------------------------------------------------------------------------        
-# EventGetTestCase (Similar to event)
-    # covers list and detail views 
+        self.assertDictEqual(expected_leader_data, response_leader)      
 
-    # test_get_event_list
-        # create 5 events, return all
-        # assert length of response data and status code
-
-    # test_get_event_detail
-        # create 1 event
-        # check status code OK 
-        # check if event is returned
-        # check data as well
-            # camp name must be full name
-            # date must be in formal format 
-            # status must be capitalized 
 
 class EventGetTestCase(APITestCase):
     """
@@ -995,82 +980,6 @@ class AnnouncementLatesTTestCase(APITestCase):
             'date': to_formal_mdy(expected_announcement.created_at)                  
         }        
         self.assertDictEqual(latest_announcement_data, response_announcement)
-
-    
-
-    
-
-
-class QueryLimitTestCase(APITestCase):
-    """
-    mock viewset that uses this logic e.g. Event
-    -> test on list endpoint
-        - mock 5 events
-        - query limit is an integer.
-        - query limit values to test: [-1, 0, 3, 5, 6]
-            # negative value
-            # zero
-            # less than total events
-            # exact no. of events
-            # greater than no. of events
-            # strings
-                # empty string
-    """
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.image_file = get_test_image_file()
-
-        for _ in range(5): 
-            Event.objects.create(
-            title= f'Event {_}', 
-            description= f'description {_}',
-            start_date=timezone.now(),
-            end_date=timezone.now(),
-            image = Image.objects.create(name=f'image_{_}', image=cls.image_file),  
-            is_featured=True,
-            )           
-
-        cls.event_count = len(Event.objects.all())            
-
-    def test_expected_query_integer_input(self):
-        # 0 -> returns 0 or no events
-        query_limit = 0
-        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
-        self.assertEqual(len(response.data), 0)
-        # 3 -> returns 3 events
-        query_limit = 3
-        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
-        self.assertEqual(len(response.data), query_limit)        
-        # 5 -> returns 5 events
-        query_limit = 5
-        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
-        self.assertEqual(len(response.data), query_limit)           
-        # 6 -> returns 5 events
-        query_limit = 6
-        response = self.client.get(f'/api/events/?query_limit={query_limit}')        
-        self.assertEqual(len(response.data), self.event_count)
-        # aaa -> strings are ignored
-
-    def test_negative_query_integer_input(self):
-        # -1 -> ignores negative, return all events
-        query_limit = -1
-        response = self.client.get(f'/api/events/?query_limit={query_limit}')
-        self.assertEqual(len(response.data), self.event_count)
-
-    def test_string_query_input(self):
-        query_limits = ['aaa', '*&()', '']
-
-        for query_limit in query_limits:
-            response = self.client.get(f'/api/events/?query_limit={query_limit}')        
-            self.assertEqual(len(response.data), self.event_count)   
-
-"""
-Test QueryLimitBackend: Gallery
-
-tests:
-    - if no model -> error 
-    - is used by a model that has no gallery 
-""" 
 
 
 # ---------------------------------------------------------------------------        

--- a/backend/testing/utils.py
+++ b/backend/testing/utils.py
@@ -22,19 +22,15 @@ def get_expected_image_url(file_name, request):
 def to_formal_mdy(date:datetime)->str:
     return f'{date.strftime("%B")} {date.day}, {date.year}'    
 
-def get_camp_value_via_label(label):
-    if label == CampEnum.BAYBAYON.label:
-        return CampEnum.BAYBAYON.value
-    if label == CampEnum.SUBA.label:
-        return CampEnum.SUBA.value
-    if label == CampEnum.LASANG.label:
-        return CampEnum.LASANG.value
-    if label == CampEnum.ZEROWASTE.label:
-        return CampEnum.ZEROWASTE.value
-    if label == CampEnum.GENERAL.label:
-        return CampEnum.GENERAL.value
+def to_expected_iso_format(date: datetime)->str:
+    """
+    convert to iso-8061; how date is serialized by default        
+    """
+    date = date.isoformat()
+    # +00:00 marks for UTC, which Z also represents (used by serializer as well)
+    return str(date).replace('+00:00', 'Z')
 
-    return None
+
 
 HOMEPAGE_JUMBOTRON_URL = '/api/jumbotrons/?expand=image&omit=created_at,updated_at,image.id&is_featured=True&query_limit=5'
 HOMEPAGE_EVENT_URL = '/api/events/?expand=image&fields=id,title,image.image&is_featured=True&query_limit=3'
@@ -49,4 +45,4 @@ EVENT_DETAIL_CONTRIBUTORS = '/api/events/?expand=contributors.image'
 PROJECT_DETAIL_GALLERY_LIMIT = '/api/projects/?expand=gallery,contributors&query_limit_gallery=10'
 PROJECT_DETAIL_CONTRIBUTORS = '/api/projects/?expand=contributors.image'
 
-
+ANNOUNCEMENT_LATEST_ONE = '/api/announcements/?omit=created_at,updated_at&query_limit=1'


### PR DESCRIPTION
latest announcement endpoint:
`/api/announcements/?omit=created_at,updated_at&query_limit=1`