### PR TITLE
reimplement: formatted date to iso format

### DIFF
--- a/backend/kalunwa/content/serializers.py
+++ b/backend/kalunwa/content/serializers.py
@@ -88,10 +88,6 @@ class OccurenceSerializer(FlexFieldsSerializerMixin, serializers.Serializer):
         # might be more appropriate to do display manipulations at the frontend
     # alternative: another field for datetime (for post/create) and display (get/list)? 
     status = serializers.SerializerMethodField()
-    start_date = serializers.SerializerMethodField()
-    end_date = serializers.SerializerMethodField()   
-    created_at =  serializers.SerializerMethodField()
-    updated_at = serializers.SerializerMethodField()
     camp = serializers.CharField(source='get_camp')
 
     class Meta:
@@ -129,18 +125,6 @@ class OccurenceSerializer(FlexFieldsSerializerMixin, serializers.Serializer):
             )               
 
         }
-
-    def get_start_date(self, obj):
-        return to_formal_mdy(obj.start_date)
-
-    def get_end_date(self, obj):
-        return to_formal_mdy(obj.end_date)
-
-    def get_created_at(self, obj):
-        return to_formal_mdy(obj.created_at)
-
-    def get_updated_at(self, obj):
-        return to_formal_mdy(obj.updated_at)
 
     def validate(self, data): # object-level validation
         data = self.get_initial() # gets pre-validation data
@@ -180,7 +164,6 @@ class ProjectSerializer(OccurenceSerializer, serializers.ModelSerializer):
 
 
 class NewsSerializer(FlexFieldsModelSerializer):
-    date = serializers.SerializerMethodField()    
     class Meta:
         model = News
         fields = (
@@ -188,7 +171,6 @@ class NewsSerializer(FlexFieldsModelSerializer):
             'title',
             'description',
             'image',
-            'date', # might ask frontend to do the formal format (Month dd, yyyy)
             'created_at',
             'updated_at',
         )
@@ -201,11 +183,10 @@ class NewsSerializer(FlexFieldsModelSerializer):
             ),
         }        
 
-    def get_date(self, obj):
-        return to_formal_mdy(obj.created_at)
-        
-
 # prep for about us 
+# will have separate serializer when posting 
+    # position, camp, and name fields cannot be posted given the use of get_methods
+    # unless the to_internal value is changed
 class CampLeaderSerializer(FlexFieldsSerializerMixin, serializers.ModelSerializer):
     position = serializers.CharField(source='get_position')
     camp = serializers.CharField(source='get_camp')   
@@ -235,8 +216,9 @@ class CampLeaderSerializer(FlexFieldsSerializerMixin, serializers.ModelSerialize
             ),
         }           
 
-
-
+# will have separate serializer when posting 
+    # name cannot be posted given the use of a get method
+    # unless the to_internal value is changed
 class CampPageSerializer(FlexFieldsModelSerializer):
     name = serializers.CharField(source='get_name') # behavior for creating data
     camp_leader = serializers.SerializerMethodField()
@@ -286,6 +268,9 @@ class CampPageSerializer(FlexFieldsModelSerializer):
             return None
 
 
+# will have separate serializer when posting 
+    # position cannot be posted given the use of a get method
+    # unless the to_internal value is changed
 class OrgLeaderSerializer(FlexFieldsModelSerializer):
     position = serializers.CharField(source='get_position')
 
@@ -310,6 +295,10 @@ class OrgLeaderSerializer(FlexFieldsModelSerializer):
             ),
         } 
 
+
+# will have separate serializer when posting 
+    # category cannot be posted given the use of a get method
+    # unless the to_internal value is changed
 class ContributorSerializer(FlexFieldsModelSerializer):
     category = serializers.CharField(source='get_category') 
 
@@ -336,7 +325,6 @@ class ContributorSerializer(FlexFieldsModelSerializer):
 
 
 class AnnouncementSerializer(FlexFieldsModelSerializer):
-    date = serializers.SerializerMethodField()    
     class Meta:
         model = Announcement
         fields = (
@@ -344,12 +332,9 @@ class AnnouncementSerializer(FlexFieldsModelSerializer):
             'title',
             'meta_description',
             'description',
-            'date',
             'created_at',
             'updated_at',
         )
-    def get_date(self, obj):
-        return to_formal_mdy(obj.created_at)
 
 
 class DemographicsSerializer(serializers.ModelSerializer):
@@ -364,6 +349,9 @@ class DemographicsSerializer(serializers.ModelSerializer):
             'updated_at',
         )
 
+# will have separate serializer when posting 
+    # position & category cannot be posted given the use of a get method
+    # unless the to_internal value is changed
 class CommissionerSerializer(FlexFieldsModelSerializer):
     position = serializers.CharField(source='get_position')
     category = serializers.CharField(source='get_category')
@@ -390,6 +378,10 @@ class CommissionerSerializer(FlexFieldsModelSerializer):
             ),
         } 
 
+
+# will have separate serializer when posting 
+    # position & category cannot be posted given the use of a get method
+    # unless the to_internal value is changed
 class CabinOfficerSerializer(FlexFieldsModelSerializer):
     position = serializers.CharField(source='get_position')
     camp = serializers.CharField(source='get_camp')

--- a/backend/testing/test_apis.py
+++ b/backend/testing/test_apis.py
@@ -20,7 +20,7 @@ from .utils import  (
     get_expected_image_url, 
     get_test_image_file, 
     to_expected_iso_format,
-    to_formal_mdy, 
+    # to_formal_mdy, 
 )
 from kalunwa.content.models import(
     Announcement,
@@ -380,7 +380,6 @@ class HomepageNewsTestCase(APITestCase):
             'id' : expected_news.id,
             'title' : expected_news.title,
             'description' : expected_news.description,
-            'date' : to_formal_mdy(expected_news.created_at),
             'image' : {'image' : image_url}
         } 
         self.assertDictEqual(news, expected_news_data)
@@ -637,11 +636,11 @@ class EventGetTestCase(APITestCase):
             'title': expected_event.title,
             'image': expected_event.image.pk, 
             'description' : expected_event.description,
-            'start_date' : to_formal_mdy(expected_event.start_date),
-            'end_date' : to_formal_mdy(expected_event.end_date),
+            'start_date' : to_expected_iso_format(expected_event.start_date),
+            'end_date' : to_expected_iso_format(expected_event.end_date),
             'camp' : expected_event.get_camp_display(),
-            'created_at': to_formal_mdy(expected_event.created_at),
-            'updated_at': to_formal_mdy(expected_event.updated_at),
+            'created_at': to_expected_iso_format(expected_event.created_at),
+            'updated_at': to_expected_iso_format(expected_event.updated_at),
             'status': StatusEnum.PAST.value # based on dates set
         }
         self.assertDictEqual(expected_event_data, response_event)
@@ -817,11 +816,11 @@ class ProjectGetTestCase(APITestCase):
             'title': expected_project.title,
             'image': expected_project.image.pk, 
             'description' : expected_project.description,
-            'start_date' : to_formal_mdy(expected_project.start_date),
-            'end_date' : to_formal_mdy(expected_project.end_date),
+            'start_date' : to_expected_iso_format(expected_project.start_date),
+            'end_date' : to_expected_iso_format(expected_project.end_date),
             'camp' : expected_project.get_camp_display(),
-            'created_at': to_formal_mdy(expected_project.created_at),
-            'updated_at': to_formal_mdy(expected_project.updated_at),
+            'created_at': to_expected_iso_format(expected_project.created_at),
+            'updated_at': to_expected_iso_format(expected_project.updated_at),
             'status': StatusEnum.PAST.value # based on dates set
         }
         self.assertDictEqual(expected_project_data, response_project)
@@ -1084,8 +1083,7 @@ class AnnouncementGetTestCase(APITestCase):
             'id': expected_announcement.id,
             'title': expected_announcement.title,
             'meta_description' : expected_announcement.meta_description,              
-            'description' : expected_announcement.description,    
-            'date': to_formal_mdy(expected_announcement.created_at),          
+            'description' : expected_announcement.description,      
             'created_at': to_expected_iso_format(expected_announcement.created_at), 
             'updated_at': to_expected_iso_format(expected_announcement.updated_at),                      
         }
@@ -1114,8 +1112,7 @@ class AnnouncementLatestTestCase(APITestCase):
             'id': expected_announcement.id,
             'title': expected_announcement.title,
             'meta_description' : expected_announcement.meta_description,             
-            'description' : expected_announcement.description,  
-            'date': to_formal_mdy(expected_announcement.created_at)                  
+            'description' : expected_announcement.description,                
         }        
         self.assertDictEqual(latest_announcement_data, response_announcement)
             
@@ -1158,8 +1155,7 @@ class NewsGetTestCase(APITestCase):
             'id': expected_news.id,
             'title': expected_news.title,           
             'description' : expected_news.description,    
-            'image': expected_news.image.pk,   
-            'date': to_formal_mdy(expected_news.created_at),       
+            'image': expected_news.image.pk,       
             'created_at': to_expected_iso_format(expected_news.created_at), 
             'updated_at': to_expected_iso_format(expected_news.updated_at),                      
         }


### PR DESCRIPTION
**changes for date:**
- changed all dates to date time
- this is due to the realization that the date's format should mostly be manipulated in the frontend, wherein the backend is to store it in its UTC format.

**News:**
    date field will be removed, recognize as -> created_at instead

**Announcement:**
    date field will be removed, recognize as -> created_at instead
(removed since their date will be based on created_at )

**Events & Project:** 
    - fields that will be returned in datetime instead of formatted string
    start_date
    end_date
    created_at
    updated_at